### PR TITLE
리펙토링

### DIFF
--- a/IndoorNavigationApp/app/src/main/cpp/opencv_native_lib.cpp
+++ b/IndoorNavigationApp/app/src/main/cpp/opencv_native_lib.cpp
@@ -46,7 +46,7 @@ Java_apriltag_OpenCVNative_draw_1polylines(JNIEnv *env, jclass clazz, jlong mat_
  */
 extern "C"
 JNIEXPORT jdoubleArray JNICALL
-Java_apriltag_OpenCVNative_find_1camera_1focal_1length(JNIEnv *env, jclass clazz,
+Java_apriltag_OpenCVNative_find_1camera_1focal_1center(JNIEnv *env, jclass clazz,
                                                        jdoubleArray tag_corner_arr,
                                                        jintArray image_size) {
 // Get CameraPosEstimation Class

--- a/IndoorNavigationApp/app/src/main/java/com/example/indoornavigationapp/view/camera/CameraFragment.kt
+++ b/IndoorNavigationApp/app/src/main/java/com/example/indoornavigationapp/view/camera/CameraFragment.kt
@@ -195,7 +195,7 @@ class CameraFragment : Fragment(), ActivityCompat.OnRequestPermissionsResultCall
 
         aprilDetections?.let {
             if (!isCameraMatInit){
-                val focalLength = OpenCVNative.find_camera_focal_length(it[0].p, intArrayOf(mSize.width, mSize.height))
+                val focalLength = OpenCVNative.find_camera_focal_center(it[0].p, intArrayOf(mSize.width, mSize.height))
                 cameraMatrixData[2] = focalLength[0] // Cx
                 cameraMatrixData[5] = focalLength[1] // Cy
                 isCameraMatInit = true
@@ -222,6 +222,7 @@ class CameraFragment : Fragment(), ActivityCompat.OnRequestPermissionsResultCall
     override fun onDestroy() {
         super.onDestroy()
         mOpenCvCameraView?.disableView()
+        aprilDetections = null
         binding = null
     }
 

--- a/IndoorNavigationApp/sdk/java/src/apriltag/OpenCVNative.java
+++ b/IndoorNavigationApp/sdk/java/src/apriltag/OpenCVNative.java
@@ -3,7 +3,7 @@ package apriltag;
 public class OpenCVNative {
     public static native void draw_polylines(long matAddrInput, double[] polygonVertexArr);
 
-    public static native double[] find_camera_focal_length(double[] arr, int[] imageSize);
+    public static native double[] find_camera_focal_center(double[] arr, int[] imageSize);
 
     public static native void draw_polylines_on_apriltag(long matAddrInput, double[] cameraMatrixData, double[] tagVertexArr, double[] polygonVertexArr);
 


### PR DESCRIPTION
- CameraFragment에서 onDestory할 때 aprilDetections 변수를 null로 변경
- find_camera_focal_length 함수 이름을 find_camera_focal_center로 변경